### PR TITLE
Proposition of a fix for the architectural problem of pagination API in Mendeley-JS-SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ var params = {
     folder_id: '345-jkl-ghj'
 };
 
-myDocumentsApi.for(JSON.stringify(params)).list().then(function (result) {
+api.documents.for(JSON.stringify(params)).list(params).then(function (result) {
     // handle the result
 });
 ```

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ var folder123Api = api.documents.for('folder_id_abc-123-xyz');
 
 folder123Api.list({folder_id: 'abc-123-xyz'}).then(function (result) {
     // handle the first page of "123" folder documents
-    // api.documents.nextPage() gets set up to retrieve the next page of "123" folder documents
+    // folder123Api.nextPage() gets set up to retrieve the next page of "123" folder documents
 });
 
 folder123Api.nextPage().then(function (result) {
@@ -180,9 +180,15 @@ myDocumentsApi.nextPage().then(function (result) {
 });
 ```
 
-Calling the ```api.endpoint.for()``` method with a falsy or no params will return the original ```api.endpoint``` instance.
+Each call to ```api.endpoint.for()``` with the same string parameter will return
+exactly tha same instance of endpoint object.
 
-The convenient way of preparing the string parameter for the ```for()``` method is serialising the params object passed to list.
+Calling the ```api.endpoint.for()``` method with a falsy or no params will return
+the original ```api.endpoint``` instance.
+
+If you work with many folders at the same time, the convenient way of preparing
+the string parameter for the ```for()``` method is serialising the params object
+passed to the ```list()``` method.
 
 Example
 ```javascript

--- a/lib/api.js
+++ b/lib/api.js
@@ -20,40 +20,38 @@ var methods = {
     setnewInstancetifier: utils.setnewInstancetifier
 };
 
-var endpoints = {
-    annotations: require('./api/annotations')(),
-    catalog: require('./api/catalog')(),
-    documents: require('./api/documents')(),
-    files: require('./api/files')(),
-    folders: require('./api/folders')(),
-    followers: require('./api/followers')(),
-    groups: require('./api/groups')(),
-    institutions: require('./api/institutions')(),
-    institutionTrees: require('./api/institution-trees')(),
-    locations: require('./api/locations')(),
-    metadata: require('./api/metadata')(),
-    profiles: require('./api/profiles')(),
-    trash: require('./api/trash')()
+var endpointFactories = {
+    annotations: require('./api/annotations'),
+    catalog: require('./api/catalog'),
+    documents: require('./api/documents'),
+    files: require('./api/files'),
+    folders: require('./api/folders'),
+    followers: require('./api/followers'),
+    groups: require('./api/groups'),
+    institutions: require('./api/institutions'),
+    institutionTrees: require('./api/institution-trees'),
+    locations: require('./api/locations'),
+    metadata: require('./api/metadata'),
+    profiles: require('./api/profiles'),
+    trash: require('./api/trash')
 };
 
-Object.keys(endpoints).forEach(function (endpointName) {
-    var instanceMap = {};
-    var endpointInstance = endpoints[endpointName];
+var endpoints = {};
 
-    endpointInstance.getInstance = function (mappingKey) {
+Object.keys(endpointFactories).forEach(function (endpointName) {
+    var instanceMap = {};
+    var firstInstance = endpointFactories[endpointName]();
+
+    endpoints[endpointName] = firstInstance;
+
+    firstInstance.for = function (mappingKey) {
         if (!mappingKey) {
-            mappingKey = '';
+            return firstInstance;
         }
 
         if (!instanceMap[mappingKey]) {
             // clone a new instance
-            instanceMap[mappingKey] = assign({}, endpointInstance);
-
-            instanceMap[mappingKey].paginationLinks = {
-                last: false,
-                next: false,
-                previous: false
-            };
+            instanceMap[mappingKey] = endpointFactories[endpointName]();
         }
 
         return instanceMap[mappingKey];

--- a/lib/api.js
+++ b/lib/api.js
@@ -15,7 +15,8 @@ if (typeof process === 'object' && process + '' === '[object process]') {
  */
 var methods = {
     setAuthFlow: utils.setAuthFlow,
-    setBaseUrl:  utils.setBaseUrl,
+    setBaseUrl: utils.setBaseUrl,
+    setNotifier: utils.setNotifier,
     setnewInstancetifier: utils.setnewInstancetifier
 };
 
@@ -47,6 +48,12 @@ Object.keys(endpoints).forEach(function (endpointName) {
         if (!instanceMap[mappingKey]) {
             // clone a new instance
             instanceMap[mappingKey] = assign({}, endpointInstance);
+
+            instanceMap[mappingKey].paginationLinks = {
+                last: false,
+                next: false,
+                previous: false
+            };
         }
 
         return instanceMap[mappingKey];

--- a/lib/api.js
+++ b/lib/api.js
@@ -50,7 +50,7 @@ Object.keys(endpointFactories).forEach(function (endpointName) {
         }
 
         if (!instanceMap[mappingKey]) {
-            // clone a new instance
+            // create a new instance
             instanceMap[mappingKey] = endpointFactories[endpointName]();
         }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var utils = require('./utilities');
+var assign = require('object-assign');
 
 if (typeof process === 'object' && process + '' === '[object process]') {
     global.window = {};
@@ -12,11 +13,13 @@ if (typeof process === 'object' && process + '' === '[object process]') {
  * @namespace
  * @name api
  */
-module.exports = {
+var methods = {
     setAuthFlow: utils.setAuthFlow,
     setBaseUrl:  utils.setBaseUrl,
-    setNotifier: utils.setNotifier,
+    setnewInstancetifier: utils.setnewInstancetifier
+};
 
+var endpoints = {
     annotations: require('./api/annotations')(),
     catalog: require('./api/catalog')(),
     documents: require('./api/documents')(),
@@ -31,3 +34,23 @@ module.exports = {
     profiles: require('./api/profiles')(),
     trash: require('./api/trash')()
 };
+
+Object.keys(endpoints).forEach(function (endpointName) {
+    var instanceMap = {};
+    var endpointInstance = endpoints[endpointName];
+
+    endpointInstance.getInstance = function (mappingKey) {
+        if (!mappingKey) {
+            mappingKey = '';
+        }
+
+        if (!instanceMap[mappingKey]) {
+            // clone a new instance
+            instanceMap[mappingKey] = assign({}, endpointInstance);
+        }
+
+        return instanceMap[mappingKey];
+    };
+});
+
+module.exports = assign(endpoints, methods);

--- a/lib/api.js
+++ b/lib/api.js
@@ -38,24 +38,32 @@ var endpointFactories = {
 
 var endpoints = {};
 
-Object.keys(endpointFactories).forEach(function (endpointName) {
+function decorateWithFor (originalInstance, factory) {
     var instanceMap = {};
-    var firstInstance = endpointFactories[endpointName]();
 
-    endpoints[endpointName] = firstInstance;
-
-    firstInstance.for = function (mappingKey) {
+    originalInstance.for = function (mappingKey) {
         if (!mappingKey) {
-            return firstInstance;
+            return originalInstance;
         }
 
         if (!instanceMap[mappingKey]) {
             // create a new instance
-            instanceMap[mappingKey] = endpointFactories[endpointName]();
+            instanceMap[mappingKey] = factory();
         }
 
         return instanceMap[mappingKey];
     };
+
+    return originalInstance;
+}
+
+Object.keys(endpointFactories).forEach(function (endpointName) {
+    var factory = endpointFactories[endpointName];
+    var originalInstance = factory();
+
+    endpoints[endpointName] = decorateWithFor(originalInstance, factory);
 });
 
-module.exports = assign(endpoints, methods);
+module.exports = assign(endpoints, methods, {
+    decorateWithFor: decorateWithFor
+});

--- a/test/spec/api.spec.js
+++ b/test/spec/api.spec.js
@@ -1,0 +1,39 @@
+/* jshint sub: true */
+'use strict';
+
+require('es5-shim');
+
+describe('api endpoints', function() {
+
+    var api = require('api');
+
+    it('are able to clone their instances', function () {
+        Object.keys(api).map(function (endpointName) {
+            return api[endpointName];
+        }).filter(function (endpointObject) {
+            // we only test enpoint objects (we skip the functions on api object)
+            typeof endpointObject === 'object';
+        }).forEach(function (endpointObject) {
+            expect(typeof endpointObject.for).toBe('function');
+        });
+    });
+
+    describe('cloned instances', function() {
+
+        it('are stored for reuse and mapped by string keys', function () {
+            var foldersApi = api.folders.for('my_documents');
+            expect(api.folders.for('my_documents')).toBe(foldersApi);
+        });
+
+        it('are unique for each key', function () {
+            var foldersApi = api.folders.for('my_documents');
+            var groupFoldersApi = api.folders.for('some_group_id');
+
+            expect(foldersApi).not.toBe(groupFoldersApi);
+            expect(foldersApi.paginationLinks).not.toBe(groupFoldersApi.paginationLinks);
+        });
+
+    });
+
+});
+/* jshint sub: false */

--- a/test/spec/api.spec.js
+++ b/test/spec/api.spec.js
@@ -18,11 +18,20 @@ describe('api endpoints', function() {
         });
     });
 
-    describe('cloned instances', function() {
+    describe('cloned instances', function () {
 
         it('are stored for reuse and mapped by string keys', function () {
             var foldersApi = api.folders.for('my_documents');
             expect(api.folders.for('my_documents')).toBe(foldersApi);
+        });
+
+        it('have identical interface', function () {
+            var foldersApi = api.folders.for('my_documents');
+            var groupFoldersApi = api.folders.for('some_group_id');
+
+            Object.keys(foldersApi).forEach(function (key) {
+                expect(typeof foldersApi[key]).toBe(typeof groupFoldersApi[key]);
+            });
         });
 
         it('are unique for each key', function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,11 +1,8 @@
-var webpack = require('webpack'),
+var webpack = require('webpack');
+var plugins = [];
+var useMinifier = (process.argv.slice(1).indexOf('--minify') !== -1);
 
-    minify = process.argv[2] === '--minify',
-    plugins = [new webpack.ProvidePlugin({
-        Promise: 'bluebird'
-    })];
-
-if (minify) {
+if (useMinifier) {
     plugins.push(new webpack.optimize.UglifyJsPlugin());
 }
 
@@ -15,8 +12,7 @@ module.exports = {
     },
     output: {
         path: './dist',
-        filename: 'standalone' + (minify ? '.min' : '') + '.js',
-
+        filename: 'standalone' + (useMinifier ? '.min' : '') + '.js',
         library: 'MendeleySDK',
         libraryTarget: 'umd'
     },
@@ -28,6 +24,6 @@ module.exports = {
             'test'
         ]
     },
-    devtool: minify ? "source-map" : "",
+    devtool: useMinifier ? 'source-map' : '',
     plugins: plugins
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,7 @@
 var webpack = require('webpack');
-var plugins = [];
+var plugins = [new webpack.ProvidePlugin({
+    Promise: 'bluebird'
+})];
 var useMinifier = (process.argv.slice(1).indexOf('--minify') !== -1);
 
 if (useMinifier) {


### PR DESCRIPTION
_Please see added README section below_
## Pagination

The API endpoint objects (e.g. `MendeleySDK.API.documents`) store their pagination state and pagination methods on themselves. This means each call of `list()` method will override the state set by previous call. This wont cause any problems as long as you only use one set of params for `list()` method, but will result in wrong pagination results if you request a list of entities with many different param sets.

Example

``` javascript
var api = require('mendeley-javascript-sdk/lib/api');

api.documents.list().then(function (result) {
    // handle the first page of "My documents"
    // api.documents.nextPage() gets set up to retrieve the next page of "My documents"
});

api.documents.list({folder_id: 'abc-123-xyz'}).then(function (result) {
    // handle the first page of "123" folder documents
    // api.documents.nextPage() gets set up to retrieve the next page of "123" folder documents
});

api.documents.nextPage().then(function (result) {
    // next page of "123" folder documents will be retrieved,
    // there's no way to retirieve the next page of "My documents" at this point
});
```

To avoid this behavior, every endpoint object allows using separate instances of itself. It also saves you the hassle of storing the instances by exposing a simple getter on the top of string-indexed map.

Example

``` javascript
var api = require('mendeley-javascript-sdk/lib/api');

// a new instance of api.documents is created under the hood and returned
var myDocumentsApi = api.documents.for('my_documents');

myDocumentsApi.list().then(function (result) {
    // handle the first page of "My documents"
    // myDocumentsApi.nextPage() gets set up to retrieve the next page of "My documents"
});


// another instance of api.documents is created for folder "123"
var folder123Api = api.documents.for('folder_id_abc-123-xyz');

folder123Api.list({folder_id: 'abc-123-xyz'}).then(function (result) {
    // handle the first page of "123" folder documents
    // folder123Api.nextPage() gets set up to retrieve the next page of "123" folder documents
});

folder123Api.nextPage().then(function (result) {
    // next page of "123" folder documents will be retrieved
});

myDocumentsApi.nextPage().then(function (result) {
    // next page of "My documents" will be retrieved independently of any other folder
});
```

Each call to `api.endpoint.for()` with the same string parameter will return
exactly tha same instance of endpoint object.

Calling the `api.endpoint.for()` method with a falsy or no params will return
the original `api.endpoint` instance.

If you work with many folders at the same time, the convenient way of preparing
the string parameter for the `for()` method is serialising the params object
passed to the `list()` method.

Example

``` javascript
var api = require('mendeley-javascript-sdk/lib/api');

var params = {
    group_id: 'zxc-876-cbm',
    folder_id: '345-jkl-ghj'
};

myDocumentsApi.for(JSON.stringify(params)).list().then(function (result) {
    // handle the result
});
```
